### PR TITLE
Remove unused dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "call-me-maybe": "^1.0.1",
     "concat-stream": "^1.6.0",
-    "debug": "^2.6.1",
-    "memory-cache-ttl": "^1.0.48"
+    "debug": "^2.6.1"
   },
   "devDependencies": {
     "tape": "^4.6.3"


### PR DESCRIPTION
dat is currently broken cause this dep is doing weird babel stuff on install. this module doesn't seem to be used to i removed it which fixes the issue.

quick merge + release appreciated as you cannot currently install dat.