### PR TITLE
Fix failing tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -68,12 +68,12 @@ tape('A bad hostname fails gracefully', function (t) {
   })
 })
 
-tape('Successful test against www.datprotocol.com', function (t) {
-  datDns.resolveName('www.datprotocol.com', function (err, name) {
+tape('Successful test against beakerbrowser.com', function (t) {
+  datDns.resolveName('beakerbrowser.com', function (err, name) {
     t.error(err)
     t.ok(/[0-9a-f]{64}/.test(name))
 
-    datDns.resolveName('www.datprotocol.com').then(function (name2) {
+    datDns.resolveName('beakerbrowser.com').then(function (name2) {
       t.equal(name, name2)
       t.end()
     }).catch(function (err) {

--- a/test.js
+++ b/test.js
@@ -76,6 +76,9 @@ tape('Successful test against www.datprotocol.com', function (t) {
     datDns.resolveName('www.datprotocol.com').then(function (name2) {
       t.equal(name, name2)
       t.end()
+    }).catch(function (err) {
+      t.error(err)
+      t.end()
     })
   })
 })


### PR DESCRIPTION
A failure in the `www.datprotocol.com` test was terminating the entire test run. It seems the `.well-known/dat` isn't set anymore for this domain. To address this I've made two changes:

- [x] Catch the promise rejection to continue the other tests on failure
- [x] Use `beakerbrowser.com` instead of `www.datprotocol.com` to make everything pass again