### PR TITLE
Use a random DNS provider (Cloudflare, Google, or Quad9) instead of using Google exclusively

### DIFF
--- a/test.js
+++ b/test.js
@@ -89,6 +89,14 @@ tape('A bad DNS record fails gracefully', function (t) {
   })
 })
 
+tape('Unqualified domain fails gracefully', function (t) {
+  datDns.resolveName('bad-dat-domain-name', function (err, name) {
+    t.ok(err)
+    t.notOk(name)
+    t.end()
+  })
+})
+
 tape('Successful test against beakerbrowser.com', function (t) {
   datDns.resolveName('beakerbrowser.com', function (err, name) {
     t.error(err)
@@ -135,7 +143,7 @@ tape('Successful test against beakerbrowser.com (no well-known/dat)', function (
 })
 
 tape('List cache', function (t) {
-  t.is(Object.keys(datDns.listCache()).length, 5)
+  t.is(Object.keys(datDns.listCache()).length, 6)
   t.end()
 })
 


### PR DESCRIPTION
Unless configured otherwise, use one of three random DoH providers. All three providers promise not to log per-user requests and have a globally distributed anycast network. Though all three are using data for business intelligence purposes.

Ideally Dat should rely on the system configured DNS and not hardcode any providers. This change reduces Dat’s dependency on just a single DNS provider and [to a small degree] helps maintain the decentralized nature of DNS. This change also makes it harder to block Dat by blocking access to a single DNS provider. Minutely increase end-user privacy by not constantly feeding one DNS provider data about the user.

This can be further improved by choosing a random provider for every request and retrying using another provider is the primary provider is unavailable. However, this is still an improvement over the current single vendor approach.
 
I also snuck in a fix to ensure lookups are made against FQDNs only.