### PR TITLE
Fix broken DNS lookups

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ module.exports = function (datDnsOpts) {
 function fetchDnsOverHttpsRecord (name, {host, path}) {
   return new Promise((resolve, reject) => {
     // ensure the name is a FQDN
-    if (!name.contains('.')) {
+    if (!name.includes('.')) {
       debug('dns-over-https failed', name, 'Not an a FQDN')
       datDns.emit('failed', {
         method: 'dns-over-https',


### PR DESCRIPTION
I apologize for this stupid mistake. I remember trying to “cleanup” the code before committing and obviously didn’t test this thoroughly enough. The existing tests didn’t detect this as they fell back to .well-known/dat. Should add test domains with only .well-known and only DNS lookups to catch this in the future.