### PR TITLE
Fix broken Cloudflare DNS lookups

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,10 @@ function fetchDnsOverHttpsRecord (name, {host, path}) {
     https.get({
       host,
       path: `${path}?${stringify(query)}`,
+      // Cloudflare requires this exact header; luckily everyone else ignores it
+      headers: {
+        'Accept': 'application/dns-json'
+      },
       timeout: 2000
     }, function (res) {
       res.setEncoding('utf-8')


### PR DESCRIPTION
* Must be exact string (`application/dns-json, application/json` doesn’t work.)
* RFC 8427 §7.1 says it should be `application/dns+json` but that doesn’t work either.
* Quad9 and Google DNS just ignores the header.

This was always in Cloudflare’s docs but they only recently made it required.