### PR TITLE
Add support for custom protocols (e.g. cabal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Issue DNS lookups for Dat archives using HTTPS requests to the target host. Keep
 ```js
 var datDns = require('dat-dns')()
 
+// or, if you have a custom protocol
+var datDns = require('dat-dns')({
+    recordName: /* name of .well-known file */
+    protocolRegex: /* RegExp object for custom protocol */,
+    hashRegex: /* RegExp object for custom hash i.e. */,
+    txtRegex: /* RegExp object for DNS TXT record of custom protocol */,
+})
+
+// example: 
+var cabalDns = require('dat-dns')({
+    recordName: 'cabal',
+    hashRegex: /^[0-9a-f]{64}?$/i,
+    protocolRegex: /^cabal:\/\/([0-9a-f]{64})/i,
+    txtRegex: /^"?cabalkey=([0-9a-f]{64})"?$/i
+})
+
 // resolve a name: pass the hostname by itself
 datDns.resolveName('foo.com', function (err, key) { ... })
 datDns.resolveName('foo.com').then(key => ...)

--- a/test.js
+++ b/test.js
@@ -1,7 +1,33 @@
 var tape = require('tape')
 var datDns = require('./index')()
+var cabalDns = require('./index')({
+    hashRegex: /^[0-9a-f]{64}?$/i,
+    recordName: 'cabal',
+    protocolRegex: /^cabal:\/\/([0-9a-f]{64})/i,
+    txtRegex: /^"?cabalkey=([0-9a-f]{64})"?$/i
+})
 
 var FAKE_DAT = 'f'.repeat(64)
+
+tape('Successful test against cblgh.org', function (t) {
+  cabalDns.resolveName('cblgh.org', function (err, name) {
+    t.error(err)
+    t.ok(/[0-9a-f]{64}/.test(name))
+
+    cabalDns.resolveName('cblgh.org').then(function (name2) {
+      t.equal(name, name2)
+      t.end()
+    })
+  })
+})
+
+tape('Works for keys', function (t) {
+  cabalDns.resolveName('14bc77d788fdaf07b89b28e9d276e47f2e44011f4adb981921056e1b3b40e99e', function (err, name) {
+    t.error(err)
+    t.equal(name, '14bc77d788fdaf07b89b28e9d276e47f2e44011f4adb981921056e1b3b40e99e')
+    t.end()
+  })
+})
 
 tape('Successful test against pfrazee.hashbase.io', function (t) {
   datDns.resolveName('pfrazee.hashbase.io', function (err, name) {


### PR DESCRIPTION
Hiya! 

I added support for custom protocols such that this PR now makes it possible to do

```js
  var cabalDns = require('dat-dns')({
      hashRegex: /^[0-9a-f]{64}?$/i,
      recordName: 'cabal',
      protocolRegex: /^cabal:\/\/([0-9a-f]{64})/i,
      txtRegex: /^"?cabalkey=([0-9a-f]{64})"?$/i
  })

cabalDns.resolve("cabal://cblgh.org").then(console.log)
```

The previous default behaviour has been maintained (you don't need to pass in any object to make `dat-dns` work with dat) and everything that worked before works the same now.

The tests all pass, except for 
```js
# Successful test against beakerbrowser.com (no well-known/dat)
running...
res Error: Global or local TTL needs to be set
```
**which also fails currently for `dat-dns`** so it's nothing that I introduced :) 

(a quick glance at the TXT records for beakerbrowser.com makes it seem as if the TXT records there need to be setup again?)

I also cleaned up a bit of the code and fixed a bug, updated the readme with my contributions and added a couple tests.

ping @pfrazee @da2x