### PR TITLE
Update Google DNS endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const DAT_TXT_REGEX = /^"?datkey=([0-9a-f]{64})"?$/i
 const VERSION_REGEX = /(\+[^\/]+)$/
 const DEFAULT_DAT_DNS_TTL = 3600 // 1hr
 const MAX_DAT_DNS_TTL = 3600 * 24 * 7 // 1 week
-const DEFAULT_DNS_PROVIDERS = [['cloudflare-dns.com', '/dns-query'], ['dns.google.com', '/resolve'], ['dns.quad9.net', '/dns-query']]
+const DEFAULT_DNS_PROVIDERS = [['cloudflare-dns.com', '/dns-query'], ['dns.google', '/resolve'], ['dns.quad9.net', '/dns-query']]
 
 // helper to support node6
 function _asyncToGenerator (fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step (key, arg) { try { var info = gen[key](arg); var value = info.value } catch (error) { reject(error); return } if (info.done) { resolve(value) } else { return Promise.resolve(value).then(function (value) { step('next', value) }, function (err) { step('throw', err) }) } } return step('next') }) } }


### PR DESCRIPTION
New endpoint address announcement:
https://security.googleblog.com/2019/06/google-public-dns-over-https-doh.htm