### PR TITLE
Relax dnsTxtRegex to support hybrid key values

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const concat = require('concat-stream')
 const DAT_HASH_REGEX = /^[0-9a-f]{64}?$/i
 const DAT_PROTOCOL_REGEX = /^dat:\/\/([0-9a-f]{64})/i
 const DAT_RECORD_NAME = 'dat'
-const DAT_TXT_REGEX = /^"?datkey=([0-9a-f]{64})"?$/i
+const DAT_TXT_REGEX = /"?datkey=([0-9a-f]{64})"?/i
 const VERSION_REGEX = /(\+[^\/]+)$/
 const DEFAULT_DAT_DNS_TTL = 3600 // 1hr
 const MAX_DAT_DNS_TTL = 3600 * 24 * 7 // 1 week


### PR DESCRIPTION
I am developing a project that needs to have both the dat key and other keys in the TXT record. Here is what is looks like:

```
datkey=3390cfcc601a97174f1221aa7277e0e5b49e5f3e973e4edecac0c66791c882c4;l=53.52294522577663,-113.30244317650795
```

The proposed change would allow the TXT record to be more flexible to support hybrid records that have other key=values in it.