### PR TITLE
Tune memory cache cleaning

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,10 @@ module.exports = function (datDnsOpts) {
   var recordName = datDnsOpts.recordName || DAT_RECORD_NAME
   var pCache = datDnsOpts.persistentCache
   var mCache = memoryCache()
-  mCache.init({ttl: 60})
+  mCache.init({
+    ttl: 60,
+    interval: datDnsOpts.cacheCleanSeconds || 60,
+  });
   var dnsHost
   var dnsPort
   var dnsPath


### PR DESCRIPTION
The memory cache sets a timer to clean the cache every second. This is much more frequent than we need (TTLs are measured in hours). This can have an energy impact as it prevents the process and CPU from going idle.

This PR exposes the option to override this interval to module consumers, as well as setting a higher default of 60 seconds.