### PR TITLE
Add redirect support (limit: 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ datDns.resolveName('foo.com', {noDnsOverHttps: true})
 // dont use .well-known/dat
 datDns.resolveName('foo.com', {noWellknownDat: true})
 
+// specify amount of redirects (default: 7)
+datDns.resolveName('foo.com', { followRedirects: 2 })
+
 // list all entries in the cache
 datDns.listCache()
 


### PR DESCRIPTION
Improved implementation of #27. I used the findings of #27 and restructured the changes a bit, fixing a few things:

- Add option (and docs) to specify how many redirects are allowed.
- Add mention in the log where the redirect is heading to
- Fixing log statement to show consistently where the well-known file is actually loaded.
- Moving the redirect code to own function for clearer code (to not explode the side of the main function)
- Using lowerCamelCase variable names
- Only prefix the path with `.well-known` for the first request (but not redirects)
- Adds test for too many redirects.
- Uses a domain dedicated to test the redirects.

Closes #25